### PR TITLE
Improve publish command resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,12 +243,17 @@ goversion publish
 If `gh` is missing or unauthenticated, publishing continues without a GitHub Release and prints an actionable warning.
 A failure from an available and authenticated `gh` command remains fatal so a real release error is not silently ignored.
 Use `-no-release` to intentionally omit the GitHub Release or `-no-proxy` for a private module that should not reach the public proxy.
+The CLI prints each phase before starting it, and each external `git`, `gh`, or `go` command has a two-minute timeout by default.
+Proxy seeding retries recognized transient HTTP and network failures up to three times with short backoff while reporting each retry.
+Permanent module and checksum failures are not retried.
+Use `-timeout` to change the per-command limit or a negative duration such as `-timeout=-1s` to disable it.
 Nested Go modules are rejected because the existing versioning step creates repository-root tags.
 
 ```console
 goversion publish -dry
 goversion publish -remote upstream
 goversion publish -proxy https://proxy.golang.org
+goversion publish -timeout 5m
 goversion publish -no-release
 goversion publish -no-proxy
 ```

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ goversion publish
 If `gh` is missing or unauthenticated, publishing continues without a GitHub Release and prints an actionable warning.
 A failure from an available and authenticated `gh` command remains fatal so a real release error is not silently ignored.
 Use `-no-release` to intentionally omit the GitHub Release or `-no-proxy` for a private module that should not reach the public proxy.
-The CLI prints each phase before starting it, and each external `git`, `gh`, or `go` command has a two-minute timeout by default.
+The CLI prints each phase before starting it and streams stdout and stderr from each external `git`, `gh`, or `go` command as it runs.
+Each external command has a two-minute timeout by default.
 Proxy seeding retries recognized transient HTTP and network failures up to three times with short backoff while reporting each retry.
 Permanent module and checksum failures are not retried.
 Use `-timeout` to change the per-command limit or a negative duration such as `-timeout=-1s` to disable it.

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -1,6 +1,7 @@
 package goversion
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"go/ast"
@@ -61,8 +62,8 @@ type PublishOptions struct {
 	// Timeout limits each external git, gh, and go command.
 	// It defaults to two minutes. A negative value disables the timeout.
 	Timeout time.Duration
-	// Progress receives status messages before each publish phase.
-	// It may be nil to disable progress output.
+	// Progress receives status messages and live stdout and stderr from external commands.
+	// It may be nil to disable progress and command output.
 	Progress io.Writer
 }
 
@@ -104,6 +105,7 @@ type publishCommandRunner interface {
 type execPublishCommandRunner struct {
 	ctx     context.Context
 	timeout time.Duration
+	output  io.Writer
 }
 
 func (runner execPublishCommandRunner) Run(dir string, env []string, name string, args ...string) ([]byte, error) {
@@ -120,14 +122,21 @@ func (runner execPublishCommandRunner) Run(dir string, env []string, name string
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), env...)
-	output, err := cmd.CombinedOutput()
+	var captured bytes.Buffer
+	var output io.Writer = &captured
+	if runner.output != nil {
+		output = io.MultiWriter(&captured, runner.output)
+	}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Run()
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		if runner.timeout > 0 && ctxErr == context.DeadlineExceeded {
-			return output, fmt.Errorf("command timed out after %s: %w", runner.timeout, ctxErr)
+			return captured.Bytes(), fmt.Errorf("command timed out after %s: %w", runner.timeout, ctxErr)
 		}
-		return output, ctxErr
+		return captured.Bytes(), ctxErr
 	}
-	return output, err
+	return captured.Bytes(), err
 }
 
 func (execPublishCommandRunner) LookPath(name string) (string, error) {
@@ -171,7 +180,7 @@ func PublishContext(ctx context.Context, options PublishOptions) (PublishMeta, e
 	if timeout == 0 {
 		timeout = defaultPublishTimeout
 	}
-	return publish(options, execPublishCommandRunner{ctx: ctx, timeout: timeout})
+	return publish(options, execPublishCommandRunner{ctx: ctx, timeout: timeout, output: options.Progress})
 }
 
 func publish(options PublishOptions, runner publishCommandRunner) (PublishMeta, error) {

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -1,15 +1,18 @@
 package goversion
 
 import (
+	"context"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
@@ -17,8 +20,9 @@ import (
 )
 
 const (
-	defaultPublishRemote = "origin"
-	defaultPublishProxy  = "https://proxy.golang.org"
+	defaultPublishRemote  = "origin"
+	defaultPublishProxy   = "https://proxy.golang.org"
+	defaultPublishTimeout = 2 * time.Minute
 )
 
 // PublishStepStatus describes the state of one step in a publish operation.
@@ -54,6 +58,12 @@ type PublishOptions struct {
 	NoProxy bool
 	// NoRelease skips GitHub Release creation.
 	NoRelease bool
+	// Timeout limits each external git, gh, and go command.
+	// It defaults to two minutes. A negative value disables the timeout.
+	Timeout time.Duration
+	// Progress receives status messages before each publish phase.
+	// It may be nil to disable progress output.
+	Progress io.Writer
 }
 
 // PublishMeta describes the module release and the state of each publish step.
@@ -88,15 +98,36 @@ type publishCommandRunner interface {
 	Run(dir string, env []string, name string, args ...string) ([]byte, error)
 	LookPath(name string) (string, error)
 	TempDir(pattern string) (string, error)
+	Sleep(duration time.Duration) error
 }
 
-type execPublishCommandRunner struct{}
+type execPublishCommandRunner struct {
+	ctx     context.Context
+	timeout time.Duration
+}
 
-func (execPublishCommandRunner) Run(dir string, env []string, name string, args ...string) ([]byte, error) {
-	cmd := exec.Command(name, args...)
+func (runner execPublishCommandRunner) Run(dir string, env []string, name string, args ...string) ([]byte, error) {
+	ctx := runner.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cancel := func() {}
+	if runner.timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, runner.timeout)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), env...)
-	return cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if runner.timeout > 0 && ctxErr == context.DeadlineExceeded {
+			return output, fmt.Errorf("command timed out after %s: %w", runner.timeout, ctxErr)
+		}
+		return output, ctxErr
+	}
+	return output, err
 }
 
 func (execPublishCommandRunner) LookPath(name string) (string, error) {
@@ -105,6 +136,21 @@ func (execPublishCommandRunner) LookPath(name string) (string, error) {
 
 func (execPublishCommandRunner) TempDir(pattern string) (string, error) {
 	return os.MkdirTemp("", pattern)
+}
+
+func (runner execPublishCommandRunner) Sleep(duration time.Duration) error {
+	ctx := runner.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Publish publishes an existing version commit and tag as a Go module release.
@@ -116,7 +162,16 @@ func (execPublishCommandRunner) TempDir(pattern string) (string, error) {
 // warning and skips the GitHub Release. Retrying Publish after a failure reuses
 // completed Git refs and an existing GitHub Release before continuing.
 func Publish(options PublishOptions) (PublishMeta, error) {
-	return publish(options, execPublishCommandRunner{})
+	return PublishContext(context.Background(), options)
+}
+
+// PublishContext behaves like Publish and cancels active external commands when ctx is done.
+func PublishContext(ctx context.Context, options PublishOptions) (PublishMeta, error) {
+	timeout := options.Timeout
+	if timeout == 0 {
+		timeout = defaultPublishTimeout
+	}
+	return publish(options, execPublishCommandRunner{ctx: ctx, timeout: timeout})
 }
 
 func publish(options PublishOptions, runner publishCommandRunner) (PublishMeta, error) {
@@ -126,6 +181,8 @@ func publish(options PublishOptions, runner publishCommandRunner) (PublishMeta, 
 		ReleaseStatus: PublishStepPending,
 		ProxyStatus:   PublishStepPending,
 	}
+
+	publishProgress(options.Progress, "Validating module and version")
 
 	workDir := options.WorkDir
 	if workDir == "" {
@@ -179,14 +236,21 @@ func publish(options PublishOptions, runner publishCommandRunner) (PublishMeta, 
 	}
 	meta.Version = version
 
+	publishProgress(options.Progress, "Inspecting local and remote Git state")
 	gitState, err := inspectPublishGit(workDir, modPath, &meta, runner)
 	if err != nil {
 		return meta, err
 	}
 
 	if options.DryRun {
+		publishProgress(options.Progress, "Validating Git ref publication (dry run)")
 		if err := validatePublishGitRefs(workDir, &meta, gitState, runner); err != nil {
 			return meta, err
+		}
+		if options.NoRelease {
+			publishProgress(options.Progress, "Skipping GitHub Release")
+		} else {
+			publishProgress(options.Progress, "Checking GitHub Release")
 		}
 		if err := publishGitHubRelease(workDir, gitState.remoteURL, &meta, runner, options.NoRelease, true); err != nil {
 			return meta, err
@@ -195,17 +259,34 @@ func publish(options PublishOptions, runner publishCommandRunner) (PublishMeta, 
 		return meta, nil
 	}
 
+	publishProgress(options.Progress, "Publishing Git refs")
 	if err := publishGitRefs(workDir, &meta, gitState, runner); err != nil {
 		return meta, err
+	}
+	if options.NoRelease {
+		publishProgress(options.Progress, "Skipping GitHub Release")
+	} else {
+		publishProgress(options.Progress, "Creating or reusing GitHub Release")
 	}
 	if err := publishGitHubRelease(workDir, gitState.remoteURL, &meta, runner, options.NoRelease, false); err != nil {
 		return meta, err
 	}
-	if err := seedPublishProxy(filepath.Dir(modPath), proxy, &meta, runner, options.NoProxy); err != nil {
+	if options.NoProxy {
+		publishProgress(options.Progress, "Skipping Go module proxy")
+	} else {
+		publishProgress(options.Progress, "Seeding Go module proxy")
+	}
+	if err := seedPublishProxy(filepath.Dir(modPath), proxy, &meta, runner, options.Progress, options.NoProxy); err != nil {
 		return meta, err
 	}
 
 	return meta, nil
+}
+
+func publishProgress(output io.Writer, message string) {
+	if output != nil {
+		fmt.Fprintf(output, "==> %s...\n", message)
+	}
 }
 
 func moduleVersionTag(gitRoot, moduleDir, version string) (string, error) {

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	defaultPublishRemote  = "origin"
-	defaultPublishProxy   = "https://proxy.golang.org"
-	defaultPublishTimeout = 2 * time.Minute
+	defaultPublishRemote    = "origin"
+	defaultPublishProxy     = "https://proxy.golang.org"
+	defaultPublishTimeout   = 2 * time.Minute
+	publishCommandWaitDelay = time.Second
 )
 
 // PublishStepStatus describes the state of one step in a publish operation.
@@ -63,7 +64,7 @@ type PublishOptions struct {
 	// It defaults to two minutes. A negative value disables the timeout.
 	Timeout time.Duration
 	// Progress receives status messages and live stdout and stderr from external commands.
-	// It may be nil to disable progress and command output.
+	// Writes are best effort. It may be nil to disable progress and command output.
 	Progress io.Writer
 }
 
@@ -108,35 +109,46 @@ type execPublishCommandRunner struct {
 	output  io.Writer
 }
 
-func (runner execPublishCommandRunner) Run(dir string, env []string, name string, args ...string) ([]byte, error) {
-	ctx := runner.ctx
-	if ctx == nil {
-		ctx = context.Background()
+type publishCommandOutput struct {
+	captured bytes.Buffer
+	streamed io.Writer
+}
+
+func (output *publishCommandOutput) Write(data []byte) (int, error) {
+	_, _ = output.captured.Write(data)
+	if output.streamed != nil {
+		_, _ = output.streamed.Write(data)
 	}
+	return len(data), nil
+}
+
+func (runner execPublishCommandRunner) Run(dir string, env []string, name string, args ...string) ([]byte, error) {
+	parent := runner.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx := parent
 	cancel := func() {}
 	if runner.timeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, runner.timeout)
+		ctx, cancel = context.WithTimeout(parent, runner.timeout)
 	}
 	defer cancel()
 
+	output := publishCommandOutput{streamed: runner.output}
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), env...)
-	var captured bytes.Buffer
-	var output io.Writer = &captured
-	if runner.output != nil {
-		output = io.MultiWriter(&captured, runner.output)
-	}
-	cmd.Stdout = output
-	cmd.Stderr = output
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	cmd.WaitDelay = publishCommandWaitDelay
 	err := cmd.Run()
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		if runner.timeout > 0 && ctxErr == context.DeadlineExceeded {
-			return captured.Bytes(), fmt.Errorf("command timed out after %s: %w", runner.timeout, ctxErr)
-		}
-		return captured.Bytes(), ctxErr
+	if parentErr := parent.Err(); parentErr != nil {
+		return output.captured.Bytes(), parentErr
 	}
-	return captured.Bytes(), err
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return output.captured.Bytes(), fmt.Errorf("command timed out after %s: %w", runner.timeout, ctxErr)
+	}
+	return output.captured.Bytes(), err
 }
 
 func (execPublishCommandRunner) LookPath(name string) (string, error) {

--- a/pkg/publish_github.go
+++ b/pkg/publish_github.go
@@ -1,6 +1,7 @@
 package goversion
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"strings"
@@ -25,6 +26,9 @@ func publishGitHubRelease(workDir, remoteURL string, meta *PublishMeta, runner p
 	}
 	authOutput, err := runner.Run(workDir, nil, "gh", authArgs...)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return publishCommandError("check GitHub authentication", authOutput, err, "gh", authArgs...)
+		}
 		meta.ReleaseStatus = PublishStepSkipped
 		warning := "GitHub release skipped because gh authentication failed; run gh auth login and retry"
 		if detail := strings.TrimSpace(string(authOutput)); detail != "" {

--- a/pkg/publish_github_test.go
+++ b/pkg/publish_github_test.go
@@ -1,6 +1,7 @@
 package goversion
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -39,6 +40,22 @@ func TestPublishGitHubUnavailable(t *testing.T) {
 				t.Fatalf("unexpected release metadata: %+v", meta)
 			}
 		})
+	}
+}
+
+func TestPublishGitHubAuthenticationTimeoutIsFatal(t *testing.T) {
+	runner := &publishTestRunner{t: t, commands: []publishTestCommand{
+		{name: "gh", args: []string{"auth", "status", "--hostname", "example.com"}, err: context.DeadlineExceeded},
+	}}
+	meta := PublishMeta{Tag: "v1.2.3", Version: "v1.2.3", ReleaseStatus: PublishStepPending}
+
+	err := publishGitHubRelease(t.TempDir(), "git@example.com:acme/tool.git", &meta, runner, false, false)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "check GitHub authentication") {
+		t.Fatalf("expected fatal authentication timeout, got %v", err)
+	}
+	runner.done()
+	if meta.ReleaseStatus != PublishStepPending || len(meta.Warnings) != 0 {
+		t.Fatalf("authentication timeout was incorrectly skipped: %+v", meta)
 	}
 }
 

--- a/pkg/publish_proxy.go
+++ b/pkg/publish_proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -17,6 +18,14 @@ func planPublishProxy(meta *PublishMeta, disabled bool) {
 		return
 	}
 	meta.ProxyStatus = PublishStepPlanned
+}
+
+var transientProxyStatus = regexp.MustCompile(`\b(?:429|5[0-9]{2})\b`)
+
+type proxyDownloadResponse struct {
+	Path    string
+	Version string
+	Error   string
 }
 
 func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publishCommandRunner, progress io.Writer, disabled bool) error {
@@ -35,43 +44,38 @@ func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publish
 	moduleVersion := meta.ModulePath + "@" + meta.Version
 	args := []string{"mod", "download", "-json", moduleVersion}
 	env := []string{"GOWORK=off", "GOPROXY=" + proxy, "GOMODCACHE=" + moduleCache}
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
+	for attempt := 1; ; attempt++ {
 		output, commandErr := runner.Run(moduleDir, env, "go", args...)
-		if commandErr != nil {
-			if attempt < maxAttempts && retryableProxyFailure(output, commandErr) {
-				if err := waitToRetryProxy(runner, progress, attempt, maxAttempts); err != nil {
-					return fmt.Errorf("wait to retry Go module proxy: %w", err)
-				}
-				continue
-			}
-			return publishCommandError("seed Go module proxy", output, commandErr, "go", args...)
+		attemptErr := validateProxyDownload(output, commandErr, meta, args)
+		if attemptErr == nil {
+			meta.ProxyStatus = PublishStepCompleted
+			return nil
 		}
-
-		var download struct {
-			Path    string
-			Version string
-			Error   string
+		if attempt >= maxAttempts || !retryableProxyFailure(output, attemptErr) {
+			return attemptErr
 		}
-		if err := json.Unmarshal(output, &download); err != nil {
-			return fmt.Errorf("verify Go module proxy response: decode go mod download output: %w", err)
+		if err := waitToRetryProxy(runner, progress, attempt, maxAttempts); err != nil {
+			return fmt.Errorf("wait to retry Go module proxy: %w", err)
 		}
-		if download.Error != "" {
-			if attempt < maxAttempts && retryableProxyFailure([]byte(download.Error), nil) {
-				if err := waitToRetryProxy(runner, progress, attempt, maxAttempts); err != nil {
-					return fmt.Errorf("wait to retry Go module proxy: %w", err)
-				}
-				continue
-			}
-			return fmt.Errorf("verify Go module proxy response: %s", download.Error)
-		}
-		if download.Path != meta.ModulePath || download.Version != meta.Version {
-			return fmt.Errorf("verify Go module proxy response: got %s@%s, want %s@%s", download.Path, download.Version, meta.ModulePath, meta.Version)
-		}
-
-		meta.ProxyStatus = PublishStepCompleted
-		return nil
 	}
-	return errors.New("seed Go module proxy: retry attempts exhausted")
+}
+
+func validateProxyDownload(output []byte, commandErr error, meta *PublishMeta, args []string) error {
+	if commandErr != nil {
+		return publishCommandError("seed Go module proxy", output, commandErr, "go", args...)
+	}
+
+	var download proxyDownloadResponse
+	if err := json.Unmarshal(output, &download); err != nil {
+		return fmt.Errorf("verify Go module proxy response: decode go mod download output: %w", err)
+	}
+	if download.Error != "" {
+		return fmt.Errorf("verify Go module proxy response: %s", download.Error)
+	}
+	if download.Path != meta.ModulePath || download.Version != meta.Version {
+		return fmt.Errorf("verify Go module proxy response: got %s@%s, want %s@%s", download.Path, download.Version, meta.ModulePath, meta.Version)
+	}
+	return nil
 }
 
 func waitToRetryProxy(runner publishCommandRunner, progress io.Writer, attempt, maxAttempts int) error {
@@ -84,18 +88,21 @@ func retryableProxyFailure(output []byte, err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
-	detail := strings.ToLower(string(output))
+	detail := strings.ToLower(string(output) + "\n" + err.Error())
+	if transientProxyStatus.MatchString(detail) {
+		return true
+	}
 	for _, marker := range []string{
-		"429 too many requests",
-		"500 internal server error",
-		"502 bad gateway",
-		"503 service unavailable",
-		"504 gateway timeout",
 		"connection refused",
 		"connection reset",
+		"connection timed out",
+		"i/o timeout",
+		"server misbehaving",
 		"temporary failure",
 		"tls handshake timeout",
 		"unexpected eof",
+		"http2:",
+		"stream error",
 	} {
 		if strings.Contains(detail, marker) {
 			return true

--- a/pkg/publish_proxy.go
+++ b/pkg/publish_proxy.go
@@ -1,9 +1,14 @@
 package goversion
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
+	"time"
 )
 
 func planPublishProxy(meta *PublishMeta, disabled bool) {
@@ -14,7 +19,7 @@ func planPublishProxy(meta *PublishMeta, disabled bool) {
 	meta.ProxyStatus = PublishStepPlanned
 }
 
-func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publishCommandRunner, disabled bool) error {
+func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publishCommandRunner, progress io.Writer, disabled bool) error {
 	if disabled {
 		meta.ProxyStatus = PublishStepSkipped
 		return nil
@@ -26,29 +31,75 @@ func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publish
 	}
 	defer os.RemoveAll(moduleCache)
 
+	const maxAttempts = 3
 	moduleVersion := meta.ModulePath + "@" + meta.Version
 	args := []string{"mod", "download", "-json", moduleVersion}
 	env := []string{"GOWORK=off", "GOPROXY=" + proxy, "GOMODCACHE=" + moduleCache}
-	output, err := runner.Run(moduleDir, env, "go", args...)
-	if err != nil {
-		return publishCommandError("seed Go module proxy", output, err, "go", args...)
-	}
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		output, commandErr := runner.Run(moduleDir, env, "go", args...)
+		if commandErr != nil {
+			if attempt < maxAttempts && retryableProxyFailure(output, commandErr) {
+				if err := waitToRetryProxy(runner, progress, attempt, maxAttempts); err != nil {
+					return fmt.Errorf("wait to retry Go module proxy: %w", err)
+				}
+				continue
+			}
+			return publishCommandError("seed Go module proxy", output, commandErr, "go", args...)
+		}
 
-	var download struct {
-		Path    string
-		Version string
-		Error   string
-	}
-	if err := json.Unmarshal(output, &download); err != nil {
-		return fmt.Errorf("verify Go module proxy response: decode go mod download output: %w", err)
-	}
-	if download.Error != "" {
-		return fmt.Errorf("verify Go module proxy response: %s", download.Error)
-	}
-	if download.Path != meta.ModulePath || download.Version != meta.Version {
-		return fmt.Errorf("verify Go module proxy response: got %s@%s, want %s@%s", download.Path, download.Version, meta.ModulePath, meta.Version)
-	}
+		var download struct {
+			Path    string
+			Version string
+			Error   string
+		}
+		if err := json.Unmarshal(output, &download); err != nil {
+			return fmt.Errorf("verify Go module proxy response: decode go mod download output: %w", err)
+		}
+		if download.Error != "" {
+			if attempt < maxAttempts && retryableProxyFailure([]byte(download.Error), nil) {
+				if err := waitToRetryProxy(runner, progress, attempt, maxAttempts); err != nil {
+					return fmt.Errorf("wait to retry Go module proxy: %w", err)
+				}
+				continue
+			}
+			return fmt.Errorf("verify Go module proxy response: %s", download.Error)
+		}
+		if download.Path != meta.ModulePath || download.Version != meta.Version {
+			return fmt.Errorf("verify Go module proxy response: got %s@%s, want %s@%s", download.Path, download.Version, meta.ModulePath, meta.Version)
+		}
 
-	meta.ProxyStatus = PublishStepCompleted
-	return nil
+		meta.ProxyStatus = PublishStepCompleted
+		return nil
+	}
+	return errors.New("seed Go module proxy: retry attempts exhausted")
+}
+
+func waitToRetryProxy(runner publishCommandRunner, progress io.Writer, attempt, maxAttempts int) error {
+	delay := time.Duration(attempt) * time.Second
+	publishProgress(progress, fmt.Sprintf("Go module proxy attempt %d/%d failed transiently; retrying in %s", attempt, maxAttempts, delay))
+	return runner.Sleep(delay)
+}
+
+func retryableProxyFailure(output []byte, err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	detail := strings.ToLower(string(output))
+	for _, marker := range []string{
+		"429 too many requests",
+		"500 internal server error",
+		"502 bad gateway",
+		"503 service unavailable",
+		"504 gateway timeout",
+		"connection refused",
+		"connection reset",
+		"temporary failure",
+		"tls handshake timeout",
+		"unexpected eof",
+	} {
+		if strings.Contains(detail, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/publish_proxy_test.go
+++ b/pkg/publish_proxy_test.go
@@ -2,10 +2,26 @@ package goversion
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
+
+func proxyTestCommand(output string, err error) publishTestCommand {
+	return publishTestCommand{
+		name: "go",
+		args: []string{"mod", "download", "-json", "example.com/acme/tool@v1.2.3"},
+		env:  []string{"GOWORK=off", "GOPROXY=https://proxy.example"},
+		out:  output,
+		err:  err,
+	}
+}
+
+func proxyTestMeta() PublishMeta {
+	return PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
+}
 
 func TestPlanPublishProxy(t *testing.T) {
 	for _, test := range []struct {
@@ -28,9 +44,9 @@ func TestPlanPublishProxy(t *testing.T) {
 
 func TestSeedPublishProxy(t *testing.T) {
 	runner := &publishTestRunner{t: t, commands: []publishTestCommand{
-		{name: "go", args: []string{"mod", "download", "-json", "example.com/acme/tool@v1.2.3"}, env: []string{"GOWORK=off", "GOPROXY=https://proxy.example"}, out: "{\"Path\":\"example.com/acme/tool\",\"Version\":\"v1.2.3\"}\n"},
+		proxyTestCommand(`{"Path":"example.com/acme/tool","Version":"v1.2.3"}`, nil),
 	}}
-	meta := PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
+	meta := proxyTestMeta()
 
 	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false); err != nil {
 		t.Fatalf("seedPublishProxy returned error: %v", err)
@@ -42,23 +58,18 @@ func TestSeedPublishProxy(t *testing.T) {
 }
 
 func TestSeedPublishProxyRetriesTransientFailure(t *testing.T) {
-	command := publishTestCommand{
-		name: "go",
-		args: []string{"mod", "download", "-json", "example.com/acme/tool@v1.2.3"},
-		env:  []string{"GOWORK=off", "GOPROXY=https://proxy.example"},
-	}
 	runner := &publishTestRunner{t: t, commands: []publishTestCommand{
-		{name: command.name, args: command.args, env: command.env, out: `{"Error":"reading proxy: 500 Internal Server Error"}`, err: errors.New("exit 1")},
-		{name: command.name, args: command.args, env: command.env, out: `{"Path":"example.com/acme/tool","Version":"v1.2.3"}`},
+		proxyTestCommand(`{"Error":"reading proxy: 500 Internal Server Error"}`, errors.New("exit 1")),
+		proxyTestCommand(`{"Path":"example.com/acme/tool","Version":"v1.2.3"}`, nil),
 	}}
-	meta := PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
+	meta := proxyTestMeta()
 	var progress bytes.Buffer
 
 	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, &progress, false); err != nil {
 		t.Fatalf("seedPublishProxy returned error: %v", err)
 	}
 	runner.done()
-	if len(runner.sleeps) != 1 || runner.sleeps[0].String() != "1s" {
+	if len(runner.sleeps) != 1 || runner.sleeps[0] != time.Second {
 		t.Fatalf("unexpected retry delays: %v", runner.sleeps)
 	}
 	if !strings.Contains(progress.String(), "attempt 1/3 failed transiently; retrying in 1s") {
@@ -69,11 +80,64 @@ func TestSeedPublishProxyRetriesTransientFailure(t *testing.T) {
 	}
 }
 
+func TestSeedPublishProxyExhaustsTransientRetries(t *testing.T) {
+	failure := proxyTestCommand(`{"Error":"reading proxy: 503 Service Unavailable"}`, errors.New("exit 1"))
+	runner := &publishTestRunner{t: t, commands: []publishTestCommand{failure, failure, failure}}
+	meta := proxyTestMeta()
+
+	err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false)
+	if err == nil || !strings.Contains(err.Error(), "503 Service Unavailable") {
+		t.Fatalf("expected final proxy error, got %v", err)
+	}
+	runner.done()
+	if len(runner.sleeps) != 2 || runner.sleeps[0] != time.Second || runner.sleeps[1] != 2*time.Second {
+		t.Fatalf("unexpected retry delays: %v", runner.sleeps)
+	}
+}
+
+func TestSeedPublishProxyStopsWhenBackoffIsCanceled(t *testing.T) {
+	runner := &publishTestRunner{
+		t:        t,
+		sleepErr: context.Canceled,
+		commands: []publishTestCommand{
+			proxyTestCommand(`{"Error":"reading proxy: 500 Internal Server Error"}`, errors.New("exit 1")),
+		},
+	}
+	meta := proxyTestMeta()
+
+	err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled backoff, got %v", err)
+	}
+	runner.done()
+}
+
+func TestRetryableProxyFailure(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		err    error
+		want   bool
+	}{
+		{name: "server error", output: "500 Internal Server Error", err: errors.New("exit 1"), want: true},
+		{name: "transport timeout", err: errors.New("dial tcp: i/o timeout"), want: true},
+		{name: "missing version", output: "404 Not Found", err: errors.New("exit 1")},
+		{name: "command timeout", output: "500 Internal Server Error", err: context.DeadlineExceeded},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := retryableProxyFailure([]byte(test.output), test.err); got != test.want {
+				t.Fatalf("retryableProxyFailure() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestSeedPublishProxyRejectsMismatchedResponse(t *testing.T) {
 	runner := &publishTestRunner{t: t, commands: []publishTestCommand{
-		{name: "go", args: []string{"mod", "download", "-json", "example.com/acme/tool@v1.2.3"}, env: []string{"GOWORK=off", "GOPROXY=https://proxy.example"}, out: "{\"Path\":\"example.com/acme/other\",\"Version\":\"v1.2.3\"}\n"},
+		proxyTestCommand(`{"Path":"example.com/acme/other","Version":"v1.2.3"}`, nil),
 	}}
-	meta := PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
+	meta := proxyTestMeta()
 
 	err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false)
 	if err == nil || !strings.Contains(err.Error(), "verify Go module proxy response") {
@@ -99,9 +163,9 @@ func TestSeedPublishProxyDisabled(t *testing.T) {
 
 func TestSeedPublishProxyError(t *testing.T) {
 	runner := &publishTestRunner{t: t, commands: []publishTestCommand{
-		{name: "go", args: []string{"mod", "download", "-json", "example.com/acme/tool@v1.2.3"}, env: []string{"GOWORK=off", "GOPROXY=https://proxy.example"}, out: "not found\n", err: errors.New("exit 1")},
+		proxyTestCommand("not found\n", errors.New("exit 1")),
 	}}
-	meta := PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
+	meta := proxyTestMeta()
 
 	err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false)
 	if err == nil || !strings.Contains(err.Error(), "seed Go module proxy") {

--- a/pkg/publish_proxy_test.go
+++ b/pkg/publish_proxy_test.go
@@ -1,6 +1,7 @@
 package goversion
 
 import (
+	"bytes"
 	"errors"
 	"strings"
 	"testing"
@@ -31,10 +32,38 @@ func TestSeedPublishProxy(t *testing.T) {
 	}}
 	meta := PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
 
-	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, false); err != nil {
+	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false); err != nil {
 		t.Fatalf("seedPublishProxy returned error: %v", err)
 	}
 	runner.done()
+	if meta.ProxyStatus != PublishStepCompleted {
+		t.Fatalf("got proxy status %q, want %q", meta.ProxyStatus, PublishStepCompleted)
+	}
+}
+
+func TestSeedPublishProxyRetriesTransientFailure(t *testing.T) {
+	command := publishTestCommand{
+		name: "go",
+		args: []string{"mod", "download", "-json", "example.com/acme/tool@v1.2.3"},
+		env:  []string{"GOWORK=off", "GOPROXY=https://proxy.example"},
+	}
+	runner := &publishTestRunner{t: t, commands: []publishTestCommand{
+		{name: command.name, args: command.args, env: command.env, out: `{"Error":"reading proxy: 500 Internal Server Error"}`, err: errors.New("exit 1")},
+		{name: command.name, args: command.args, env: command.env, out: `{"Path":"example.com/acme/tool","Version":"v1.2.3"}`},
+	}}
+	meta := PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
+	var progress bytes.Buffer
+
+	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, &progress, false); err != nil {
+		t.Fatalf("seedPublishProxy returned error: %v", err)
+	}
+	runner.done()
+	if len(runner.sleeps) != 1 || runner.sleeps[0].String() != "1s" {
+		t.Fatalf("unexpected retry delays: %v", runner.sleeps)
+	}
+	if !strings.Contains(progress.String(), "attempt 1/3 failed transiently; retrying in 1s") {
+		t.Fatalf("missing retry progress output: %q", progress.String())
+	}
 	if meta.ProxyStatus != PublishStepCompleted {
 		t.Fatalf("got proxy status %q, want %q", meta.ProxyStatus, PublishStepCompleted)
 	}
@@ -46,7 +75,7 @@ func TestSeedPublishProxyRejectsMismatchedResponse(t *testing.T) {
 	}}
 	meta := PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
 
-	err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, false)
+	err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false)
 	if err == nil || !strings.Contains(err.Error(), "verify Go module proxy response") {
 		t.Fatalf("expected proxy verification error, got %v", err)
 	}
@@ -60,7 +89,7 @@ func TestSeedPublishProxyDisabled(t *testing.T) {
 	runner := &publishTestRunner{t: t}
 	meta := PublishMeta{ProxyStatus: PublishStepPending}
 
-	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, true); err != nil {
+	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, true); err != nil {
 		t.Fatalf("seedPublishProxy returned error: %v", err)
 	}
 	if meta.ProxyStatus != PublishStepSkipped {
@@ -74,7 +103,7 @@ func TestSeedPublishProxyError(t *testing.T) {
 	}}
 	meta := PublishMeta{ModulePath: "example.com/acme/tool", Version: "v1.2.3", ProxyStatus: PublishStepPending}
 
-	err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, false)
+	err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false)
 	if err == nil || !strings.Contains(err.Error(), "seed Go module proxy") {
 		t.Fatalf("expected proxy error, got %v", err)
 	}

--- a/pkg/publish_test.go
+++ b/pkg/publish_test.go
@@ -1,6 +1,8 @@
 package goversion
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -8,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 type publishTestCommand struct {
@@ -23,6 +26,8 @@ type publishTestRunner struct {
 	commands []publishTestCommand
 	calls    []publishTestCommand
 	lookErr  error
+	sleeps   []time.Duration
+	sleepErr error
 }
 
 func (runner *publishTestRunner) Run(_ string, env []string, name string, args ...string) ([]byte, error) {
@@ -69,6 +74,11 @@ func (runner *publishTestRunner) LookPath(name string) (string, error) {
 
 func (runner *publishTestRunner) TempDir(_ string) (string, error) {
 	return runner.t.TempDir(), nil
+}
+
+func (runner *publishTestRunner) Sleep(duration time.Duration) error {
+	runner.sleeps = append(runner.sleeps, duration)
+	return runner.sleepErr
 }
 
 func (runner *publishTestRunner) done() {
@@ -150,12 +160,40 @@ func TestPublishDryRunDisabledSteps(t *testing.T) {
 	tag := "v1.2.3"
 	runner := preflightRunnerWithRefs(t, dir, head, tag, "git@example.com:acme/tool.git", head, head)
 
-	meta, err := publish(PublishOptions{WorkDir: dir, DryRun: true, NoRelease: true, NoProxy: true}, runner)
+	var progress bytes.Buffer
+	meta, err := publish(PublishOptions{WorkDir: dir, DryRun: true, NoRelease: true, NoProxy: true, Progress: &progress}, runner)
 	if err != nil {
 		t.Fatalf("Publish dry run returned error: %v", err)
 	}
 	runner.done()
 	assertPublishStatuses(t, meta, PublishStepReused, PublishStepReused, PublishStepSkipped, PublishStepSkipped)
+	wantProgress := "==> Validating module and version...\n" +
+		"==> Inspecting local and remote Git state...\n" +
+		"==> Validating Git ref publication (dry run)...\n" +
+		"==> Skipping GitHub Release...\n"
+	if progress.String() != wantProgress {
+		t.Fatalf("unexpected progress output:\n%s\nwant:\n%s", progress.String(), wantProgress)
+	}
+}
+
+func TestExecPublishCommandRunnerTimeout(t *testing.T) {
+	if os.Getenv("GOVERSION_TIMEOUT_TEST_HELPER") == "1" {
+		time.Sleep(5 * time.Second)
+		return
+	}
+
+	runner := execPublishCommandRunner{ctx: context.Background(), timeout: 20 * time.Millisecond}
+	started := time.Now()
+	_, err := runner.Run("", []string{"GOVERSION_TIMEOUT_TEST_HELPER=1"}, os.Args[0], "-test.run=^TestExecPublishCommandRunnerTimeout$")
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("timed-out command took %s to return", elapsed)
+	}
+	if !strings.Contains(err.Error(), "command timed out after 20ms") {
+		t.Fatalf("timeout error is not actionable: %v", err)
+	}
 }
 
 func TestPublishRejectsModuleMajorMismatch(t *testing.T) {

--- a/pkg/publish_test.go
+++ b/pkg/publish_test.go
@@ -176,6 +176,29 @@ func TestPublishDryRunDisabledSteps(t *testing.T) {
 	}
 }
 
+func TestExecPublishCommandRunnerStreamsOutput(t *testing.T) {
+	if os.Getenv("GOVERSION_OUTPUT_TEST_HELPER") == "1" {
+		fmt.Fprintln(os.Stdout, "child stdout")
+		fmt.Fprintln(os.Stderr, "child stderr")
+		return
+	}
+
+	var streamed bytes.Buffer
+	runner := execPublishCommandRunner{ctx: context.Background(), timeout: time.Second, output: &streamed}
+	output, err := runner.Run("", []string{"GOVERSION_OUTPUT_TEST_HELPER=1"}, os.Args[0], "-test.run=^TestExecPublishCommandRunnerStreamsOutput$")
+	if err != nil {
+		t.Fatalf("helper command failed: %v", err)
+	}
+	for _, want := range []string{"child stdout", "child stderr"} {
+		if !strings.Contains(string(output), want) {
+			t.Errorf("captured output does not contain %q: %q", want, output)
+		}
+		if !strings.Contains(streamed.String(), want) {
+			t.Errorf("streamed output does not contain %q: %q", want, streamed.String())
+		}
+	}
+}
+
 func TestExecPublishCommandRunnerTimeout(t *testing.T) {
 	if os.Getenv("GOVERSION_TIMEOUT_TEST_HELPER") == "1" {
 		time.Sleep(5 * time.Second)

--- a/pkg/publish_test.go
+++ b/pkg/publish_test.go
@@ -5,13 +5,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
 
 type publishTestCommand struct {
 	name string
@@ -167,12 +175,15 @@ func TestPublishDryRunDisabledSteps(t *testing.T) {
 	}
 	runner.done()
 	assertPublishStatuses(t, meta, PublishStepReused, PublishStepReused, PublishStepSkipped, PublishStepSkipped)
-	wantProgress := "==> Validating module and version...\n" +
-		"==> Inspecting local and remote Git state...\n" +
-		"==> Validating Git ref publication (dry run)...\n" +
-		"==> Skipping GitHub Release...\n"
-	if progress.String() != wantProgress {
-		t.Fatalf("unexpected progress output:\n%s\nwant:\n%s", progress.String(), wantProgress)
+	for _, message := range []string{
+		"Validating module and version",
+		"Inspecting local and remote Git state",
+		"Validating Git ref publication (dry run)",
+		"Skipping GitHub Release",
+	} {
+		if !strings.Contains(progress.String(), message) {
+			t.Errorf("progress output does not contain %q: %q", message, progress.String())
+		}
 	}
 }
 
@@ -184,7 +195,11 @@ func TestExecPublishCommandRunnerStreamsOutput(t *testing.T) {
 	}
 
 	var streamed bytes.Buffer
-	runner := execPublishCommandRunner{ctx: context.Background(), timeout: time.Second, output: &streamed}
+	runner := execPublishCommandRunner{
+		ctx:     context.Background(),
+		timeout: 10 * time.Second,
+		output:  io.MultiWriter(&streamed, failingWriter{}),
+	}
 	output, err := runner.Run("", []string{"GOVERSION_OUTPUT_TEST_HELPER=1"}, os.Args[0], "-test.run=^TestExecPublishCommandRunnerStreamsOutput$")
 	if err != nil {
 		t.Fatalf("helper command failed: %v", err)
@@ -216,6 +231,51 @@ func TestExecPublishCommandRunnerTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "command timed out after 20ms") {
 		t.Fatalf("timeout error is not actionable: %v", err)
+	}
+}
+
+func TestExecPublishCommandRunnerBoundsInheritedOutput(t *testing.T) {
+	if os.Getenv("GOVERSION_WAIT_TEST_GRANDCHILD") == "1" {
+		for {
+			if _, err := os.Stdout.Write([]byte(".")); err != nil {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if os.Getenv("GOVERSION_WAIT_TEST_CHILD") == "1" {
+		child := exec.Command(os.Args[0], "-test.run=^TestExecPublishCommandRunnerBoundsInheritedOutput$")
+		child.Env = append(os.Environ(), "GOVERSION_WAIT_TEST_GRANDCHILD=1")
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		if err := child.Start(); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	runner := execPublishCommandRunner{ctx: context.Background(), timeout: 10 * time.Second}
+	started := time.Now()
+	_, err := runner.Run("", []string{"GOVERSION_WAIT_TEST_CHILD=1"}, os.Args[0], "-test.run=^TestExecPublishCommandRunnerBoundsInheritedOutput$")
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("expected bounded inherited output error, got %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("inherited output took %s to close", elapsed)
+	}
+}
+
+func TestExecPublishCommandRunnerPreservesParentDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	runner := execPublishCommandRunner{ctx: ctx, timeout: time.Minute}
+
+	_, err := runner.Run("", []string{"GOVERSION_TIMEOUT_TEST_HELPER=1"}, os.Args[0], "-test.run=^TestExecPublishCommandRunnerTimeout$")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected parent deadline, got %v", err)
+	}
+	if strings.Contains(err.Error(), "command timed out after") {
+		t.Fatalf("parent deadline was mislabeled as command timeout: %v", err)
 	}
 }
 

--- a/publish_cli.go
+++ b/publish_cli.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"time"
 
 	goversion "github.com/bcomnes/goversion/v2/pkg"
 )
@@ -15,6 +16,7 @@ func runPublishCommand(arguments []string, output, errorOutput io.Writer) int {
 	workDir := flags.String("workdir", ".", "Go module working directory")
 	remote := flags.String("remote", "origin", "Git remote to publish to")
 	proxy := flags.String("proxy", "https://proxy.golang.org", "Go module proxy to seed after publishing")
+	timeout := flags.Duration("timeout", 2*time.Minute, "Maximum duration of each external command; use a negative duration to disable")
 	dryRun := flags.Bool("dry", false, "Validate and preview publishing without changing remote state")
 	noProxy := flags.Bool("no-proxy", false, "Push and create the GitHub release without seeding a Go module proxy")
 	noRelease := flags.Bool("no-release", false, "Push and seed the Go proxy without creating a GitHub Release")
@@ -45,6 +47,8 @@ func runPublishCommand(arguments []string, output, errorOutput io.Writer) int {
 		DryRun:      *dryRun,
 		NoProxy:     *noProxy,
 		NoRelease:   *noRelease,
+		Timeout:     *timeout,
+		Progress:    errorOutput,
 	})
 	if err != nil {
 		fmt.Fprintln(errorOutput, "Error:", err)

--- a/publish_cli_test.go
+++ b/publish_cli_test.go
@@ -13,8 +13,10 @@ func TestCLIPublishHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("publish help failed: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "goversion publish [options]") {
-		t.Errorf("expected publish help output, got:\n%s", out)
+	for _, want := range []string{"goversion publish [options]", "-timeout duration"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("publish help does not contain %q:\n%s", want, out)
+		}
 	}
 }
 
@@ -63,7 +65,7 @@ func TestCLIPublishToLocalRemote(t *testing.T) {
 	if err != nil {
 		t.Fatalf("publish failed: %v\n%s", err, output)
 	}
-	if !strings.Contains(string(output), "Go module published successfully!") {
+	if !strings.Contains(string(output), "Go module published successfully!") || !strings.Contains(string(output), "==> Validating module and version...") {
 		t.Fatalf("unexpected publish output:\n%s", output)
 	}
 


### PR DESCRIPTION
## Summary

- report publish phases as they begin and stream child-process stdout and stderr
- bound each external git, gh, and go command with a configurable timeout
- add context-aware cancellation for library callers
- retry transient Go proxy HTTP and network failures with bounded backoff
- keep permanent module and checksum failures immediate

## Validation

- go test ./...
- successfully resumed and seeded github.com/bcomnes/gogogo@v0.1.0 after the original proxy failure