### PR TITLE
Decouple proxy seeding from checksum database

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ A failure from an available and authenticated `gh` command remains fatal so a re
 Use `-no-release` to intentionally omit the GitHub Release or `-no-proxy` for a private module that should not reach the public proxy.
 The CLI prints each phase before starting it and streams stdout and stderr from each external `git`, `gh`, or `go` command as it runs.
 Each external command has a two-minute timeout by default.
-Proxy seeding retries recognized transient HTTP and network failures up to three times with short backoff while reporting each retry.
-Permanent module and checksum failures are not retried.
+Proxy seeding reports each attempt and retries recognized transient HTTP and network failures up to three times with short backoff.
+It disables checksum-database lookup for this isolated fetch so `sum.golang.org` availability cannot block verification of the configured module proxy.
+Permanent module and proxy-response failures are not retried.
 Use `-timeout` to change the per-command limit or a negative duration such as `-timeout=-1s` to disable it.
 Nested Go modules are rejected because the existing versioning step creates repository-root tags.
 

--- a/pkg/publish_proxy.go
+++ b/pkg/publish_proxy.go
@@ -43,8 +43,9 @@ func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publish
 	const maxAttempts = 3
 	moduleVersion := meta.ModulePath + "@" + meta.Version
 	args := []string{"mod", "download", "-json", moduleVersion}
-	env := []string{"GOWORK=off", "GOPROXY=" + proxy, "GOMODCACHE=" + moduleCache}
+	env := []string{"GOWORK=off", "GOSUMDB=off", "GOPROXY=" + proxy, "GOMODCACHE=" + moduleCache}
 	for attempt := 1; ; attempt++ {
+		publishProgress(progress, fmt.Sprintf("Go module proxy attempt %d/%d", attempt, maxAttempts))
 		output, commandErr := runner.Run(moduleDir, env, "go", args...)
 		attemptErr := validateProxyDownload(output, commandErr, meta, args)
 		if attemptErr == nil {

--- a/pkg/publish_proxy_test.go
+++ b/pkg/publish_proxy_test.go
@@ -13,7 +13,7 @@ func proxyTestCommand(output string, err error) publishTestCommand {
 	return publishTestCommand{
 		name: "go",
 		args: []string{"mod", "download", "-json", "example.com/acme/tool@v1.2.3"},
-		env:  []string{"GOWORK=off", "GOPROXY=https://proxy.example"},
+		env:  []string{"GOWORK=off", "GOSUMDB=off", "GOPROXY=https://proxy.example"},
 		out:  output,
 		err:  err,
 	}
@@ -72,8 +72,14 @@ func TestSeedPublishProxyRetriesTransientFailure(t *testing.T) {
 	if len(runner.sleeps) != 1 || runner.sleeps[0] != time.Second {
 		t.Fatalf("unexpected retry delays: %v", runner.sleeps)
 	}
-	if !strings.Contains(progress.String(), "attempt 1/3 failed transiently; retrying in 1s") {
-		t.Fatalf("missing retry progress output: %q", progress.String())
+	for _, message := range []string{
+		"Go module proxy attempt 1/3...",
+		"attempt 1/3 failed transiently; retrying in 1s",
+		"Go module proxy attempt 2/3...",
+	} {
+		if !strings.Contains(progress.String(), message) {
+			t.Fatalf("proxy progress does not contain %q: %q", message, progress.String())
+		}
 	}
 	if meta.ProxyStatus != PublishStepCompleted {
 		t.Fatalf("got proxy status %q, want %q", meta.ProxyStatus, PublishStepCompleted)

--- a/pkg/publish_test.go
+++ b/pkg/publish_test.go
@@ -110,7 +110,7 @@ func TestPublishSuccessStatuses(t *testing.T) {
 		publishTestCommand{name: "gh", args: []string{"repo", "view", remoteURL, "--json", "nameWithOwner", "--jq", ".nameWithOwner"}, out: "acme/tool\n"},
 		publishTestCommand{name: "gh", args: []string{"release", "view", tag, "--repo", "github.com/acme/tool", "--json", "url", "--jq", ".url"}, out: "release not found\n", err: errors.New("not found")},
 		publishTestCommand{name: "gh", args: []string{"release", "create", tag, "--verify-tag", "--generate-notes", "--title", tag, "--repo", "github.com/acme/tool", "--prerelease"}, out: "https://github.com/acme/tool/releases/tag/" + tag + "\n"},
-		publishTestCommand{name: "go", args: []string{"mod", "download", "-json", "example.com/acme/tool/v2@" + tag}, env: []string{"GOWORK=off", "GOPROXY=https://proxy.golang.org"}, out: "{\"Path\":\"example.com/acme/tool/v2\",\"Version\":\"" + tag + "\"}\n"},
+		publishTestCommand{name: "go", args: []string{"mod", "download", "-json", "example.com/acme/tool/v2@" + tag}, env: []string{"GOWORK=off", "GOSUMDB=off", "GOPROXY=https://proxy.golang.org"}, out: "{\"Path\":\"example.com/acme/tool/v2\",\"Version\":\"" + tag + "\"}\n"},
 	)
 
 	meta, err := publish(PublishOptions{WorkDir: dir}, runner)


### PR DESCRIPTION
## Summary

- disable checksum-database lookup for the isolated module-proxy seed request
- prevent sum.golang.org outages from blocking proxy publication verification
- report each proxy attempt before starting the potentially quiet download
- document and test the behavior

## Validation

- go test ./...
- go test -race ./pkg
- go vet ./...
- successfully resumed and seeded github.com/bcomnes/goversion/v2@v2.2.1 with GOSUMDB disabled