### PR TITLE
Format proxy verification output

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ goversion publish
 If `gh` is missing or unauthenticated, publishing continues without a GitHub Release and prints an actionable warning.
 A failure from an available and authenticated `gh` command remains fatal so a real release error is not silently ignored.
 Use `-no-release` to intentionally omit the GitHub Release or `-no-proxy` for a private module that should not reach the public proxy.
-The CLI prints each phase before starting it and streams stdout and stderr from each external `git`, `gh`, or `go` command as it runs.
+The CLI prints each phase before starting it and streams useful stdout and stderr from external `git`, `gh`, and `go` commands as they run.
+Machine-readable proxy output is captured and displayed as curated JSON without temporary cache paths.
 Each external command has a two-minute timeout by default.
 Proxy seeding reports each attempt and retries recognized transient HTTP and network failures up to three times with short backoff.
 It disables checksum-database lookup for this isolated fetch so `sum.golang.org` availability cannot block verification of the configured module proxy.

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -98,6 +98,7 @@ type PublishMeta struct {
 
 type publishCommandRunner interface {
 	Run(dir string, env []string, name string, args ...string) ([]byte, error)
+	RunCaptured(dir string, env []string, name string, args ...string) ([]byte, error)
 	LookPath(name string) (string, error)
 	TempDir(pattern string) (string, error)
 	Sleep(duration time.Duration) error
@@ -123,6 +124,14 @@ func (output *publishCommandOutput) Write(data []byte) (int, error) {
 }
 
 func (runner execPublishCommandRunner) Run(dir string, env []string, name string, args ...string) ([]byte, error) {
+	return runner.run(dir, env, runner.output, name, args...)
+}
+
+func (runner execPublishCommandRunner) RunCaptured(dir string, env []string, name string, args ...string) ([]byte, error) {
+	return runner.run(dir, env, nil, name, args...)
+}
+
+func (runner execPublishCommandRunner) run(dir string, env []string, streamed io.Writer, name string, args ...string) ([]byte, error) {
 	parent := runner.ctx
 	if parent == nil {
 		parent = context.Background()
@@ -134,7 +143,7 @@ func (runner execPublishCommandRunner) Run(dir string, env []string, name string
 	}
 	defer cancel()
 
-	output := publishCommandOutput{streamed: runner.output}
+	output := publishCommandOutput{streamed: streamed}
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), env...)

--- a/pkg/publish_proxy.go
+++ b/pkg/publish_proxy.go
@@ -23,9 +23,19 @@ func planPublishProxy(meta *PublishMeta, disabled bool) {
 var transientProxyStatus = regexp.MustCompile(`\b(?:429|5[0-9]{2})\b`)
 
 type proxyDownloadResponse struct {
-	Path    string
-	Version string
-	Error   string
+	Path     string               `json:"Path"`
+	Version  string               `json:"Version"`
+	Sum      string               `json:"Sum,omitempty"`
+	GoModSum string               `json:"GoModSum,omitempty"`
+	Origin   *proxyDownloadOrigin `json:"Origin,omitempty"`
+	Error    string               `json:"Error,omitempty"`
+}
+
+type proxyDownloadOrigin struct {
+	VCS  string `json:"VCS,omitempty"`
+	URL  string `json:"URL,omitempty"`
+	Hash string `json:"Hash,omitempty"`
+	Ref  string `json:"Ref,omitempty"`
 }
 
 func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publishCommandRunner, progress io.Writer, disabled bool) error {
@@ -46,9 +56,10 @@ func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publish
 	env := []string{"GOWORK=off", "GOSUMDB=off", "GOPROXY=" + proxy, "GOMODCACHE=" + moduleCache}
 	for attempt := 1; ; attempt++ {
 		publishProgress(progress, fmt.Sprintf("Go module proxy attempt %d/%d", attempt, maxAttempts))
-		output, commandErr := runner.Run(moduleDir, env, "go", args...)
-		attemptErr := validateProxyDownload(output, commandErr, meta, args)
+		output, commandErr := runner.RunCaptured(moduleDir, env, "go", args...)
+		download, attemptErr := validateProxyDownload(output, commandErr, meta, args)
 		if attemptErr == nil {
+			printProxyDownload(progress, download)
 			meta.ProxyStatus = PublishStepCompleted
 			return nil
 		}
@@ -61,22 +72,32 @@ func seedPublishProxy(moduleDir, proxy string, meta *PublishMeta, runner publish
 	}
 }
 
-func validateProxyDownload(output []byte, commandErr error, meta *PublishMeta, args []string) error {
+func validateProxyDownload(output []byte, commandErr error, meta *PublishMeta, args []string) (proxyDownloadResponse, error) {
 	if commandErr != nil {
-		return publishCommandError("seed Go module proxy", output, commandErr, "go", args...)
+		return proxyDownloadResponse{}, publishCommandError("seed Go module proxy", output, commandErr, "go", args...)
 	}
 
 	var download proxyDownloadResponse
 	if err := json.Unmarshal(output, &download); err != nil {
-		return fmt.Errorf("verify Go module proxy response: decode go mod download output: %w", err)
+		return download, fmt.Errorf("verify Go module proxy response: decode go mod download output: %w", err)
 	}
 	if download.Error != "" {
-		return fmt.Errorf("verify Go module proxy response: %s", download.Error)
+		return download, fmt.Errorf("verify Go module proxy response: %s", download.Error)
 	}
 	if download.Path != meta.ModulePath || download.Version != meta.Version {
-		return fmt.Errorf("verify Go module proxy response: got %s@%s, want %s@%s", download.Path, download.Version, meta.ModulePath, meta.Version)
+		return download, fmt.Errorf("verify Go module proxy response: got %s@%s, want %s@%s", download.Path, download.Version, meta.ModulePath, meta.Version)
 	}
-	return nil
+	return download, nil
+}
+
+func printProxyDownload(output io.Writer, download proxyDownloadResponse) {
+	if output == nil {
+		return
+	}
+	formatted, err := json.MarshalIndent(download, "", "\t")
+	if err == nil {
+		fmt.Fprintln(output, string(formatted))
+	}
 }
 
 func waitToRetryProxy(runner publishCommandRunner, progress io.Writer, attempt, maxAttempts int) error {

--- a/pkg/publish_proxy_test.go
+++ b/pkg/publish_proxy_test.go
@@ -44,16 +44,25 @@ func TestPlanPublishProxy(t *testing.T) {
 
 func TestSeedPublishProxy(t *testing.T) {
 	runner := &publishTestRunner{t: t, commands: []publishTestCommand{
-		proxyTestCommand(`{"Path":"example.com/acme/tool","Version":"v1.2.3"}`, nil),
+		proxyTestCommand(`{"Path":"example.com/acme/tool","Version":"v1.2.3","Info":"/tmp/cache/v1.2.3.info","Sum":"h1:module","GoModSum":"h1:gomod","Origin":{"VCS":"git","URL":"https://example.com/acme/tool","Hash":"abc123","Ref":"refs/tags/v1.2.3"}}`, nil),
 	}}
 	meta := proxyTestMeta()
+	var progress bytes.Buffer
 
-	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, nil, false); err != nil {
+	if err := seedPublishProxy(t.TempDir(), "https://proxy.example", &meta, runner, &progress, false); err != nil {
 		t.Fatalf("seedPublishProxy returned error: %v", err)
 	}
 	runner.done()
 	if meta.ProxyStatus != PublishStepCompleted {
 		t.Fatalf("got proxy status %q, want %q", meta.ProxyStatus, PublishStepCompleted)
+	}
+	for _, want := range []string{`"Path": "example.com/acme/tool"`, `"Sum": "h1:module"`, `"Origin": {`} {
+		if !strings.Contains(progress.String(), want) {
+			t.Errorf("formatted proxy output does not contain %q: %s", want, progress.String())
+		}
+	}
+	if strings.Contains(progress.String(), "Info") || strings.Contains(progress.String(), "/tmp/cache") {
+		t.Errorf("formatted proxy output contains temporary cache details: %s", progress.String())
 	}
 }
 

--- a/pkg/publish_test.go
+++ b/pkg/publish_test.go
@@ -53,6 +53,10 @@ func (runner *publishTestRunner) Run(_ string, env []string, name string, args .
 	return []byte(expected.out), expected.err
 }
 
+func (runner *publishTestRunner) RunCaptured(dir string, env []string, name string, args ...string) ([]byte, error) {
+	return runner.Run(dir, env, name, args...)
+}
+
 func publishTestEnvironmentsEqual(actual, expected []string) bool {
 	var filtered []string
 	hasModuleCache := false
@@ -211,6 +215,15 @@ func TestExecPublishCommandRunnerStreamsOutput(t *testing.T) {
 		if !strings.Contains(streamed.String(), want) {
 			t.Errorf("streamed output does not contain %q: %q", want, streamed.String())
 		}
+	}
+
+	streamed.Reset()
+	output, err = runner.RunCaptured("", []string{"GOVERSION_OUTPUT_TEST_HELPER=1"}, os.Args[0], "-test.run=^TestExecPublishCommandRunnerStreamsOutput$")
+	if err != nil {
+		t.Fatalf("captured helper command failed: %v", err)
+	}
+	if streamed.Len() != 0 || !strings.Contains(string(output), "child stdout") {
+		t.Fatalf("captured command output was streamed=%q or not returned=%q", streamed.String(), output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- capture the machine-readable go mod download response instead of streaming temporary cache paths
- display curated JSON containing module identity, checksums, and source origin
- retain the full captured response for errors and retry classification
- preserve raw streaming for other external publish commands

## Validation

- go test ./...
- go test -race ./pkg
- go vet ./...
- git diff --check